### PR TITLE
Fix GOAWAY deserialization when debug data is present

### DIFF
--- a/lib/protocol/framer.js
+++ b/lib/protocol/framer.js
@@ -736,6 +736,8 @@ typeSpecificAttributes.GOAWAY = ['last_stream', 'error'];
 //     +-+-------------------------------------------------------------+
 //     |                      Error Code (32)                          |
 //     +---------------------------------------------------------------+
+//     |                  Additional Debug Data (*)                    |
+//     +---------------------------------------------------------------+
 //
 // The last stream identifier in the GOAWAY frame contains the highest numbered stream identifier
 // for which the sender of the GOAWAY frame has received frames on and might have taken some action
@@ -759,8 +761,8 @@ Serializer.GOAWAY = function writeGoaway(frame, buffers) {
 };
 
 Deserializer.GOAWAY = function readGoaway(buffer, frame) {
-  if (buffer.length !== 8) {
-    // GOAWAY must have 8 bytes
+  if (buffer.length < 8) {
+    // GOAWAY must have at least 8 bytes
     return 'FRAME_SIZE_ERROR';
   }
   frame.last_stream = buffer.readUInt32BE(0) & 0x7fffffff;
@@ -768,6 +770,12 @@ Deserializer.GOAWAY = function readGoaway(buffer, frame) {
   if (!frame.error) {
     // Unknown error types are to be considered equivalent to INTERNAL ERROR
     frame.error = 'INTERNAL_ERROR';
+  }
+  // Read remaining data into "debug_data"
+  // https://http2.github.io/http2-spec/#GOAWAY
+  //   Endpoints MAY append opaque data to the payload of any GOAWAY frame
+  if (buffer.length > 8) {
+    frame.debug_data = buffer.slice(8);
   }
 };
 


### PR DESCRIPTION
Additional debug data is allowed to be included in the GOAWAY frame:
https://http2.github.io/http2-spec/#GOAWAY. We now put that data into
frame.debug_data instead of returning a FRAME_SIZE_ERROR. Fixes #218
and #219.